### PR TITLE
fix: ensure attachments exist before iterating

### DIFF
--- a/app/views/fields/active_storage/_form.html.erb
+++ b/app/views/fields/active_storage/_form.html.erb
@@ -30,7 +30,7 @@ By default, the input is a text field for the image's URL.
           I18n.t("administrate.fields.active_storage.replace", default: 'Replace')
     %>
     <%= f.file_field field.attribute, multiple: field.many?, direct_upload: field.direct? %>
-    <% if field.can_add_attachment? && field.many? && Rails.application.config.active_storage.replace_on_assign_to_many %>
+    <% if field.can_add_attachment? && field.many? && Rails.application.config.active_storage.replace_on_assign_to_many && field.attachments.present? %>
       <% field.attachments.each do |attachment| %>
         <%= f.hidden_field field.attribute, multiple: true, value: attachment.signed_id %>
       <% end %>


### PR DESCRIPTION
If attachments don't exist on the field, iterating over them via `each` will throw an error e.g. https://programa.sentry.io/issues/4587725154/events/7964b96a9b7a40bd9d8c453a141dd41b/
An existence check prevents this issue.